### PR TITLE
Update gophercloud dependency

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -30,7 +30,7 @@ github.com/google/go-cmp f94e52cad91c65a63acc1e75d4be223ea22e99bc
 github.com/gorilla/mux 53c1911da2b537f792e7cafcb446b05ffe33b996
 github.com/go-redis/redis 73b70592cdaa9e6abdfcfbf97b4a90d80728c836
 github.com/go-sql-driver/mysql 2e00b5cd70399450106cec6431c2e2ce3cae5034
-github.com/gophercloud/gophercloud 36954b3332102baa9d7edd7897a6cdbf5fcb03b8
+github.com/rcbops/ops-fabric-gophercloud d7e8eefefa4e665e2667140be70f326229d8a1dd
 github.com/hailocab/go-hostpool e80d13ce29ede4452c43dea11e79b9bc8a15b478
 github.com/hashicorp/consul 63d2fc68239b996096a1c55a0d4b400ea4c2583f
 github.com/influxdata/tail c43482518d410361b6c383d7aebce33d0471d7bc

--- a/plugins/inputs/openstack/openstack.go
+++ b/plugins/inputs/openstack/openstack.go
@@ -46,7 +46,7 @@ type FlavorMap map[string]flavors.Flavor
 // Typedef for an OpenStack volume
 type Volume struct {
 	volumes.Volume
-	volumetenants.VolumeExt
+	volumetenants.VolumeTenantExt
 }
 
 // Typedef for OpenStack volumes


### PR DESCRIPTION
This modifies our Godeps to pull in our custom gophercloud lib.

This is necessary because of a bug in upstream gophercloud about certain
assumptions about the hypervisors API. The bug is fixed in our fork.

Our gophercloud lib was built on top of the latest upstream master,
which made the small name switch in openstack.go necessary.